### PR TITLE
Show google api key field in controlpanel and also use it.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,9 @@ Installation
 This addon can be installed has any other addons, please follow official
 documentation_.
 
+Since 22th of June in 2016, Google changed its API policy. This means you need to have a valid api key for local (localhost) development.
+If you want to prevent the annoying JS Pop-up you need to obtain a new api key from the `Google console`_.
+
 
 Upgrading
 =========
@@ -67,3 +70,4 @@ Contributors
 .. _collective.geo.settings: http://pypi.python.org/pypi/collective.geo.settings
 .. _issue tracker: https://github.com/collective/collective.geo.bundle/issues
 .. _documentation: http://plone.org/documentation/kb/installing-add-ons-quick-how-to
+.. _Google console: https://console.developers.google.com/apis

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,10 @@ Changelog
 2.4 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Show google api key field in controlpanel and also use it.
+  Since 22th June 2016 goolge map api shows an annoying MissingKeyMapError
+  Pop-up if for new domains and localhost if you don't provide a valid api key.
+  [mathias.leimgruber]
 
 
 2.3 (2015-11-17)

--- a/src/collective/geo/mapwidget/browser/controlpanel.py
+++ b/src/collective/geo/mapwidget/browser/controlpanel.py
@@ -97,7 +97,7 @@ class GeoAdvancedConfGroup(group.Group):
 
 def control_panel_fields():
     form_fields = field.Fields(IGeoSettings).select(
-        'default_layers', 'bingapi')
+        'default_layers', 'bingapi', 'googleapi')
     form_fields += field.Fields(IGeoFeatureStyle).select(
         'map_viewlet_position')
     default_layer_field = form_fields['default_layers']

--- a/src/collective/geo/mapwidget/browser/geosettings_view.py
+++ b/src/collective/geo/mapwidget/browser/geosettings_view.py
@@ -11,7 +11,7 @@ from collective.geo.mapwidget import utils
 
 
 _BINGURL = '%s://dev.virtualearth.net/mapcontrol/mapcontrol.ashx?v=6'
-_GOOGLEURL = '%s://maps.google.com/maps/api/js?v=3.2&sensor=false'
+_GOOGLEURL = '%s://maps.google.com/maps/api/js?v=3.2&sensor=false&key=%s'
 
 
 class GeoSettingsView(object):
@@ -61,7 +61,7 @@ class GeoSettingsView(object):
     def google_maps_js(self):
         """return google maps 3 api javascript url
         """
-        return _GOOGLEURL % self.layer_protocol
+        return _GOOGLEURL % (self.layer_protocol, self.googleapi)
 
     @property
     def bingapi(self):

--- a/src/collective/geo/mapwidget/tests/test_geomacros.py
+++ b/src/collective/geo/mapwidget/tests/test_geomacros.py
@@ -45,8 +45,8 @@ class TestSetupHTTP(unittest.TestCase):
         self.geosettings.default_layers = [u'google_map']
         self.assertEquals(
             self.settings.google_maps_js,
-            '%s://maps.google.com/maps/api/js?v=3.2&sensor=false' %
-            self._protocol
+            '%s://maps.google.com/maps/api/js?v=3.2&sensor=false&key=%s' %
+            (self._protocol, self.settings.googleapi)
         )
 
         self.geosettings.default_layers = [u'osm']


### PR DESCRIPTION
Since 22th June 2016 goolge map api shows an annoying MissingKeyMapError
Pop-up for new domains and localhost if you don't provide a valid api key.


Would be glad to have this asap in a new 2.x release. 
Any feedback welcome if I have to improve the PR. 