### PR TITLE
Plone5 fixmap

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -21,6 +21,7 @@ Changelog
 
 - Fix not loaded map case when don't have jquery.tools.js and open edit view not 
   in "coordinates" tab
+- Add ImgPath in map's default options to point the resource folder
   [lucabel]
 
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -19,6 +19,10 @@ Changelog
 - Updated javascript to draw the map in new plone5 mockup hidden tab
   [pbauer]
 
+- Fix not loaded map case when don't have jquery.tools.js and open edit view not 
+  in "coordinates" tab
+  [lucabel]
+
 
 
 2.3 (2015-11-17)

--- a/src/collective/geo/mapwidget/browser/static/collectivegeo.js
+++ b/src/collective/geo/mapwidget/browser/static/collectivegeo.js
@@ -201,6 +201,7 @@
                 displayProjection: new OpenLayers.Projection("EPSG:4326"),
                 units: "m",
                 numZoomLevels: 19,
+                ImgPath: '++plone++openlayers.static/openlayers/img',
                 maxResolution: 156543.0339,
                 maxExtent: new OpenLayers.Bounds(-20037508.34, -20037508.34,
                                                   20037508.34, 20037508.34),

--- a/src/collective/geo/mapwidget/browser/static/collectivegeo_init.js
+++ b/src/collective/geo/mapwidget/browser/static/collectivegeo_init.js
@@ -115,9 +115,16 @@
         // get hidden maps (maps with no size yet)
         maps = $('.widget-cgmap').filter(':hidden');
         if (maps.length > 0) {
-            tabs = $('.autotoc-nav, .formTabs, ul.formTabs');
-            tabs.bind("onClick", function (e, index) {
-                var curpanel = $(this).data('tabs').getCurrentPane();
+            tabs = $('.autotoc-nav,.autotoc-nav a, .formTabs, ul.formTabs');
+            tabs.bind("click", function (e, index) {
+                var data = $(this).data('tabs');
+                var curpanel;
+                if (data){
+                    curpanel = $(this).data('tabs').getCurrentPane();
+                }
+                else{
+                    curpanel = $(this).parents('form').find('fieldset.active');
+                };
                 curpanel.find('.widget-cgmap').collectivegeo(); // refresh
                 curpanel.find('.map-widget .widget-cgmap').collectivegeo('add_edit_layer');
                 curpanel.find('.map-widget .widget-cgmap').collectivegeo('add_geocoder');


### PR DESCRIPTION
- Fix the case map is not loaded when you don't have jquery.tools.js (we have it in Plone4, not in Plone 5) and open the edit view not  in "coordinates" tab
- Add ImgPath in map's default options to point the new icons resource folder

