### PR TITLE
Fix bad adapter registration causing problems in dexterity factory.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.0 (unreleased)
 ----------------
 
+- Fix bad adapter registration causing dexterity add view to fail with a 404.
+  [jone]
+
 - Fix display of geocoding results
   [mpeeters]
 
@@ -32,7 +35,7 @@ Changelog
 - Updated javascript to draw the map in new plone5 mockup hidden tab
   [pbauer]
 
-- Fix not loaded map case when don't have jquery.tools.js and open edit view not 
+- Fix not loaded map case when don't have jquery.tools.js and open edit view not
   in "coordinates" tab
 - Add ImgPath in map's default options to point the resource folder
   [lucabel]

--- a/src/collective/geo/mapwidget/browser/configure.zcml
+++ b/src/collective/geo/mapwidget/browser/configure.zcml
@@ -50,9 +50,9 @@
 
     <!-- ..interfaces.IMapView -->
     <adapter
-        for="zope.interface.Interface
-             zope.interface.Interface
-             zope.interface.Interface"
+        for="zope.browser.interfaces.IBrowserView
+             zope.publisher.interfaces.browser.IBrowserRequest
+             OFS.interfaces.IItem"
         factory=".widget.MapWidgets"
         />
 

--- a/src/collective/geo/mapwidget/tests/test_defaultmaplayers.py
+++ b/src/collective/geo/mapwidget/tests/test_defaultmaplayers.py
@@ -91,6 +91,23 @@ class TestDefaultMapLayers(unittest.TestCase):
             for layer in layers:
                 self.assertEquals(layer.protocol, protocol)
 
+    def test_traversal(self):
+        """Regression test verifying that traversal is not broken by the mapwidget.
+
+        Traversing ++add++Document was resulting in the error:
+        AttributeError: 'MapWidgets' object has no attribute '__of__'
+
+        The problem is that within ++add++* an multi adapter lookup is made, where
+        the adapter is not named, has no specific provided interface and adapts
+        three objects.
+        collective.geo.mapwidget used to register the adapter for MapWidgets without
+        a provided interface and with unspecific three-tuple discriminators, causing
+        to be falsely adapted in the factory code.
+
+        This test verifies that that does not happen again.
+        """
+        self.assertTrue(self.portal.restrictedTraverse('++add++Document'))
+
 
 def test_suite():
     suite = unittest.TestSuite()


### PR DESCRIPTION
Traversing `++add++Document` (or any other factory) was resulting in the error:
```
AttributeError: 'MapWidgets' object has no attribute '__of__'
```

The problem is that within `++add++*` an multi adapter lookup is made, where the adapter is not named, has no specific provided interface and adapts three objects.

`collective.geo.mapwidget` registered the adapter for MapWidgets without a provided interface and with unspecific three-tuple discriminators, causing to be falsely adapted in the factory code.

The fix is to simply be a bit more specific in the adapter registration.