### PR TITLE
Fix tests because of change in collective.geo.settings.

### DIFF
--- a/src/collective/geo/mapwidget/browser/controlpanel.txt
+++ b/src/collective/geo/mapwidget/browser/controlpanel.txt
@@ -24,7 +24,7 @@ we log in as manager and verify the functionality of collective.geo.mapwidget co
     '10.0'
 
     >>> browser.getControl(name = 'form.widgets.imgpath').value
-    'string:${portal_url}/img/'
+    'string:${portal_url}/++plone++openlayers.static/openlayers/img/'
 
 we change the latitude and longitude coordinates and save data
     >>> browser.getControl(name = 'form.widgets.longitude').value = "-2.582259177802396"

--- a/src/collective/geo/mapwidget/tests/test_geomacros.py
+++ b/src/collective/geo/mapwidget/tests/test_geomacros.py
@@ -77,7 +77,7 @@ class TestSetupHTTP(unittest.TestCase):
 
         self.assertEqual(
             self.settings.imgpath,
-            "string:${portal_url}/img/"
+            "string:${portal_url}/++plone++openlayers.static/openlayers/img/"
         )
 
 


### PR DESCRIPTION
In https://github.com/collective/collective.geo.settings/pull/7 the resource path has changed, causing the tests of collective.geo.mapwidget to fail.