### PR TITLE
Pin down geopy to 1.x

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 2.6 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Pin geopy down to 1.x now 2.0 released.
+  [djowett-ftw]
 
 
 2.5 (2018-10-09)

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(name='collective.geo.mapwidget',
       install_requires=[
           'setuptools',
           'BeautifulSoup',
-          'geopy>=0.98',
+          'geopy>=0.98, <2.0.dev0',
           'Products.CMFCore',
           'plone.app.z3cform',
           'collective.geo.openlayers >= 3.1',


### PR DESCRIPTION
geopy 2.0 was recently released. It is for Python 3 only.