### PR TITLE
Add comment on empty ul tag

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 2.6 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Add comment on empty ul tag. Browsers delete empty ul tag now. So JQuery can not get ul tag anymore and results search are blank.
+  [bsuttor]
 
 
 2.5 (2018-10-09)

--- a/src/collective/geo/mapwidget/browser/collectivegeo_macros.pt
+++ b/src/collective/geo/mapwidget/browser/collectivegeo_macros.pt
@@ -77,7 +77,7 @@
           tal:attributes="value context/location|context/getLocation|nothing">
         <button><span i18n:translate="">Search</span></button>
         <div class="results" style="display: none">
-          <ul></ul>
+          <ul><!-- This comment is added to keep an empty tag on browser --></ul>
         </div>
         <div class="formHelp" i18n:translate="">Insert the name of the
          location you are looking for and then click on search button.


### PR DESCRIPTION
Empty "ul" tags are deleted by some accessibility tools. So JQuery can not get ul tag anymore and results search are empty.